### PR TITLE
fixes back up to 537 passing tests

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -1019,12 +1019,12 @@ function ast_for_call(c, n, func, allowgen)
                  * SF bug 132313 points out that complaining about a keyword
                  * then is very confusing.
                  */
-                if (e.constructor === Sk.ast.Lambda) {
+                if (e.constructor === Sk.astnodes.Lambda) {
                     ast_error(c, chch,
                             "lambda cannot contain assignment");
                     return NULL;
                 }
-                else if (e.constructor !== Sk.ast.Name) {
+                else if (e.constructor !== Sk.astnodes.Name) {
                     ast_error(c, chch,
                             "keyword can't be an expression");
                     return NULL;
@@ -1061,7 +1061,7 @@ function ast_for_trailer(c, n, left_expr) {
     REQ(n, SYM.trailer);
     if (TYPE(CHILD(n, 0)) == TOK.T_LPAR) {
         if (NCH(n) == 2)
-            return new Sk.ast.Call(left_expr, NULL, NULL, LINENO(n),
+            return new Sk.astnodes.Call(left_expr, NULL, NULL, LINENO(n),
                         n.col_offset);
         else
             return ast_for_call(c, CHILD(n, 1), left_expr, true);
@@ -2250,7 +2250,7 @@ function parsestr (c, s) {
 
     // treats every sequence as unicodes even if they are not treated with uU prefix
     // kinda hacking though working for most purposes
-    if((c.c_flags & Parser.CO_FUTURE_UNICODE_LITERALS || Sk.__future__.unicode_literals === true)) {
+    if((c.c_flags & Sk.Parser.CO_FUTURE_UNICODE_LITERALS || Sk.__future__.unicode_literals === true)) {
         unicode = true;
     }
 

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -323,12 +323,14 @@ SymbolTable.prototype.SEQStmt = function (nodes) {
     var val;
     var i;
     var len;
-    Sk.asserts.assert(Sk.isArrayLike(nodes), "SEQ: nodes isn't array? got " + nodes.toString());
-    len = nodes.length;
-    for (i = 0; i < len; ++i) {
-        val = nodes[i];
-        if (val) {
-            this.visitStmt(val);
+    if (nodes !== null) {
+        Sk.asserts.assert(Sk.isArrayLike(nodes), "SEQ: nodes isn't array? got " + nodes.toString());
+        len = nodes.length;
+        for (i = 0; i < len; ++i) {
+            val = nodes[i];
+            if (val) {
+                this.visitStmt(val);
+            }
         }
     }
 };
@@ -336,12 +338,14 @@ SymbolTable.prototype.SEQExpr = function (nodes) {
     var val;
     var i;
     var len;
-    Sk.asserts.assert(Sk.isArrayLike(nodes), "SEQ: nodes isn't array? got " + nodes.toString());
-    len = nodes.length;
-    for (i = 0; i < len; ++i) {
-        val = nodes[i];
-        if (val) {
-            this.visitExpr(val);
+    if (nodes !== null) {
+        Sk.asserts.assert(Sk.isArrayLike(nodes), "SEQ: nodes isn't array? got " + nodes.toString());
+        len = nodes.length;
+        for (i = 0; i < len; ++i) {
+            val = nodes[i];
+            if (val) {
+                this.visitExpr(val);
+            }
         }
     }
 };
@@ -700,7 +704,7 @@ SymbolTable.prototype.visitExpr = function (e) {
         case Sk.astnodes.Set:
             this.SEQExpr(e.elts);
             break;
-        case Sk.ast.Starred:
+        case Sk.astnodes.Starred:
             this.visitExpr(e.value);
             break;
         default:


### PR DESCRIPTION
- dict keys and values and array args are no longer an empty array when not there but null 
- .ast to .astnodes changes 
- Parser is now referenced as Sk.parser