### PR TITLE
Fix finally

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1198,17 +1198,17 @@ Compiler.prototype.peekFinallyBlock = function() {
 };
 */
 
-Compiler.prototype.pushExceptionHandlerBlock = function(blk, isFinally) {
+Compiler.prototype.pushExceptionHandlerBlock = function (blk, isFinally) {
     Sk.asserts.assert(blk >= 0 && blk < this.u.blocknum);
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
-    const excBlock = {blk, isFinally, breakDepth: this.u.breakBlocks.length};
+    const excBlock = { blk, isFinally, breakDepth: this.u.breakBlocks.length };
     this.u.exceptionHandlerBlocks.push(excBlock);
     return excBlock;
-}
+};
 
-Compiler.prototype.popExceptionHandlerBlock = function() {
+Compiler.prototype.popExceptionHandlerBlock = function () {
     this.u.exceptionHandlerBlocks.pop();
-}
+};
 
 Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(continuingOrBreaking, valueOfPostFinally) {
     // We are emitting code for a continue, break, or return. We need to close out
@@ -1235,7 +1235,7 @@ Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(con
     // After calling this code, the caller must emit a jump/return to the eventual destination. It will be ignored if we've already
     // jumped to a finally block, or it will fall through efficiently to it if all we did was pop off an exception from the stack.
     return true;
-}
+};
 
 
 Compiler.prototype.setupExcept = function (eb) {
@@ -1646,12 +1646,12 @@ Compiler.prototype.outputFinallyCascade = function (thisFinally) {
           "if($postfinally.returning) {");
 
     if(this.closeOutExceptionHandlersAndMaybeJumpToFinally(false)) {
-        out("return $postfinally.returning;")
+        out("return $postfinally.returning;");
     }
 
     out(  "} else {");
     if (this.closeOutExceptionHandlersAndMaybeJumpToFinally(true)) {
-        out("$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;")
+        out("$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;");
     }
     out(  "}",
         "}");
@@ -1810,7 +1810,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
 
     // except:
     this.setBlock(exceptionHandler);
-    out("$exc.pop()"); // skip "finally" handler
+    out("$exc.pop();"); // skip "finally" handler
 
     //   if not exit(*sys.exc_info()):
     //     raise
@@ -2633,7 +2633,7 @@ Compiler.prototype.cbreak = function(s) {
     gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
     this._jump(gotoBlock);
-}
+};
 
 /**
  * compiles a statement

--- a/src/compile.js
+++ b/src/compile.js
@@ -2619,7 +2619,7 @@ Compiler.prototype.ccontinue = function (s) {
         throw new Sk.builtin.SyntaxError("'continue' outside loop", this.filename, s.lineno);
     }
     // todo; continue out of exception blocks?
-    gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
+    const gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
     this._jump(gotoBlock);
@@ -2629,7 +2629,7 @@ Compiler.prototype.cbreak = function(s) {
     if (this.u.breakBlocks.length === 0) {
         throw new Sk.builtin.SyntaxError("'break' outside loop", this.filename, s.lineno);
     }
-    gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
+    const gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
     this._jump(gotoBlock);
 };

--- a/src/compile.js
+++ b/src/compile.js
@@ -1248,9 +1248,9 @@ Compiler.prototype.endExcept = function () {
     this.popExceptionHandlerBlock();
 };
 
-Compiler.prototype.setupFinally = function (eb) {
-    out("$exc.push(", eb, ");");
-    return this.pushExceptionHandlerBlock(eb, true);
+Compiler.prototype.setupFinally = function (finallyBody, excHandler) {
+    out("$exc.push(", excHandler , ");");
+    return this.pushExceptionHandlerBlock(finallyBody, true);
 };
 
 Compiler.prototype.endFinally = function () {
@@ -1677,7 +1677,7 @@ Compiler.prototype.ctry = function (s) {
         finalExceptionToReRaise = this._gr("finally_reraise", "undefined");
 
         this.u.tempsToSave.push(finalExceptionToReRaise);
-        thisFinally = this.setupFinally(finalBody);
+        thisFinally = this.setupFinally(finalBody, finalExceptionHandler);
     }
 
     // Create a block for each except clause
@@ -1749,7 +1749,6 @@ Compiler.prototype.ctry = function (s) {
         this._jump(finalBody);
 
         this.setBlock(finalBody);
-        this.popExceptionHandlerBlock();
         this.vseqstmt(s.finalbody);
         // If finalbody executes normally, AND we have an exception
         // to re-raise, we raise it.
@@ -1786,7 +1785,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     value = this._gr("value", "$ret");
 
     // try:
-    thisFinallyBlock = this.setupFinally(tidyUp);
+    thisFinallyBlock = this.setupFinally(tidyUp, tidyUp);
     this.setupExcept(exceptionHandler);
 
     //    VAR = value

--- a/src/compile.js
+++ b/src/compile.js
@@ -1156,6 +1156,7 @@ Compiler.prototype.newBlock = function (name) {
     this.u.blocks[ret]._next = null;
     return ret;
 };
+
 Compiler.prototype.setBlock = function (n) {
     Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
     this.u.curblock = n;
@@ -1176,27 +1177,6 @@ Compiler.prototype.pushContinueBlock = function (n) {
 Compiler.prototype.popContinueBlock = function () {
     this.u.continueBlocks.pop();
 };
-/*
-Compiler.prototype.pushExceptBlock = function (n) {
-    Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
-    this.u.exceptBlocks.push(n);
-};
-Compiler.prototype.popExceptBlock = function () {
-    this.u.exceptBlocks.pop();
-};
-
-Compiler.prototype.pushFinallyBlock = function (n) {
-    Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
-    Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
-    this.u.finallyBlocks.push({blk: n, breakDepth: this.u.breakBlocks.length});
-};
-Compiler.prototype.popFinallyBlock = function () {
-    this.u.finallyBlocks.pop();
-};
-Compiler.prototype.peekFinallyBlock = function() {
-    return (this.u.finallyBlocks.length > 0) ? this.u.finallyBlocks[this.u.finallyBlocks.length-1] : undefined;
-};
-*/
 
 Compiler.prototype.pushExceptionHandlerBlock = function (blk, isFinally) {
     Sk.asserts.assert(blk >= 0 && blk < this.u.blocknum);
@@ -1578,52 +1558,6 @@ Compiler.prototype.craise = function (s) {
     } else {
         // re-raise
         out("throw $err;");
-    }
-};
-
-Compiler.prototype.outputFinallyCascade = function (thisFinally) {
-    var nextFinally;
-
-    // What do we do when we're done executing a 'finally' block?
-    // Normally you just fall off the end. If we're 'return'ing,
-    // 'continue'ing or 'break'ing, $postfinally tells us what to do.
-    //
-    // But we might be in a nested pair of 'finally' blocks. If so, we need
-    // to work out whether to jump to the outer finally block.
-    //
-    // (NB we do NOT deal with re-raising exceptions here. That's handled
-    // elsewhere, because 'with' does special things with exceptions.)
-
-    if (this.u.finallyBlocks.length == 0) {
-        // No nested 'finally' block. Easy.
-        out("if($postfinally!==undefined) { if ($postfinally.returning) { return $postfinally.returning; } else { $blk=$postfinally.gotoBlock; $postfinally=undefined; continue; } }");
-    } else {
-
-        // OK, we're nested. Do we jump straight to the outer 'finally' block?
-        // Depends on how we got here here.
-
-        // Normal execution ($postfinally===undefined)? No, we're done here.
-
-        // Returning ($postfinally.returning)? Yes, we want to execute all the
-        // 'finally' blocks on the way out.
-
-        // Breaking ($postfinally.isBreak)? It depends. Is the outer 'finally'
-        // block inside or outside the loop we're breaking out of? We compare
-        // its breakDepth to ours to find out. If we're at the same breakDepth,
-        // we're both inside the innermost loop, so we both need to execute.
-        // ('continue' is the same thing as 'break' for us)
-
-        nextFinally = this.peekFinallyBlock();
-
-        out("if($postfinally!==undefined) {",
-            "if ($postfinally.returning",
-            (nextFinally.breakDepth == thisFinally.breakDepth) ? "|| $postfinally.isBreak" : "", ") {",
-
-            "$blk=",nextFinally.blk,";continue;",
-            "} else {",
-            "$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;",
-            "}",
-            "}");
     }
 };
 

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -14,6 +14,42 @@ class B(A):
     def __init__(self, foo):
         super().__init__(foo)
 
+i = 0
+def foo():
+    global i
+    try:
+        return
+    finally:
+        i += 1
+        raise Exception("foo")
+
+
+def foo2():
+    global i
+    while i < 5:
+        try:
+            try: pass
+            finally: break
+        except:
+            pass
+    i += 1
+    raise Exception("foo")
+
+
+class Foo:
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        global i
+        i += 1
+        raise Exception("foo")
+
+
+def foo3():
+    with Foo():
+        return
+
+
 
 class TestSuper(unittest.TestCase):
     def test_bug_1345(self):
@@ -22,6 +58,23 @@ class TestSuper(unittest.TestCase):
             B('foo')
         except Exception:
             self.fail("this shouldn't fail")
+
+    def test_finally_raises(self):
+        def helper(fn):
+            global i
+            try:
+                fn()
+            except Exception:
+                pass
+            self.assertEqual(i, 1)
+            i = 0
+
+        helper(foo)
+        helper(foo2)
+        helper(foo3)
+
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is what I came up with to do the final fixes.

Bug 1 - line 1812 `out("$exc.pop();"); // skip "finally" handler` 
was missing the semi colon which failed js syntax errors

Bug 2 - re-raising was not happening in an example like:

```python
try:
    raise Exception("foo")
finally:
    pass
print("failed to re-raise")
```

To overcome this I passed two arguments to `setupFinally` - the first was the finally body block and the second is the finally exception handler block.

The finally exception handler block is the block that gets popped when an error is thrown
The finally body block is what things like break/continue/return will jump to.
(I hope)

Another bug seemed to be line `1752` - I think this should have been removed when `endFinally` became responsible for popping the finally block.